### PR TITLE
Adjust shadow cause labels in dashboard

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -5639,10 +5639,11 @@
                 // ===== SHADOW ANALYTICS =====
                 const SHADOW_CAUSE_LABELS = {
                     'building_tree_obstruction': 'Gebäude/Baum',
-                    'low_sun_angle': 'Tiefer Sonnenstand',
+                    'low_sun_angle': 'Tiefe Sonne',
                     'panel_frost_snow': 'Schnee/Frost',
                     'weather_clouds': 'Wolken',
-                    'weather_better_than_forecast': 'Besser als Prognose',
+                    'weather_better_than_forecast': 'Besser',
+                    'clearer_than_forecast': 'Besser',
                     'night': 'Nacht',
                     'unknown': 'Unbekannt'
                 };


### PR DESCRIPTION
- Added missing clearer_than_forecast in SHADOW_CAUSE_LABELS
- Shortened strings to max. 12 characters so they fit into the box

![Schatten](https://github.com/user-attachments/assets/daaec2ac-cac2-4b29-adee-977bcc9229b1)
